### PR TITLE
Update to cassandra-3.0.15

### DIFF
--- a/TimeWindowCompactionStrategy/pom.xml
+++ b/TimeWindowCompactionStrategy/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.jeffjirsa.cassandra.db.compaction</groupId>
   <artifactId>TimeWindowCompactionStrategy</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0</version>
+  <version>3.0.15</version>
   <name>TimeWindowCompactionStrategy</name>
   <url>https://github.com/jeffjirsa/twcs</url>
   <properties>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
-      <version>3.0.0</version>
+      <version>3.0.15</version>
     </dependency>
   </dependencies>
 </project>

--- a/TimeWindowCompactionStrategy/src/main/java/com/jeffjirsa/cassandra/db/compaction/TimeWindowCompactionStrategy.java
+++ b/TimeWindowCompactionStrategy/src/main/java/com/jeffjirsa/cassandra/db/compaction/TimeWindowCompactionStrategy.java
@@ -105,7 +105,7 @@ public class TimeWindowCompactionStrategy extends AbstractCompactionStrategy
         if (System.currentTimeMillis() - lastExpiredCheck > options.expiredSSTableCheckFrequency)
         {
             logger.debug("TWCS expired check sufficiently far in the past, checking for fully expired SSTables");
-            expired = CompactionController.getFullyExpiredSSTables(cfs, uncompacting, cfs.getOverlappingSSTables(SSTableSet.CANONICAL, uncompacting), gcBefore);
+            expired = CompactionController.getFullyExpiredSSTables(cfs, uncompacting, cfs.getOverlappingLiveSSTables(uncompacting), gcBefore);
             lastExpiredCheck = System.currentTimeMillis();
         }
         else


### PR DESCRIPTION
In cassandra-3.0.9 CFS.getOverlappingSSTables() API was changed.